### PR TITLE
Remove redundant Origin header

### DIFF
--- a/src/WebSocketClient.cpp
+++ b/src/WebSocketClient.cpp
@@ -242,7 +242,7 @@ namespace cyanray
 		handshakingWords.append("Host: ").append(hostname).append(":").append(to_string(port)).append("\r\n");
 		handshakingWords.append("Connection: Upgrade").append("\r\n");
 		handshakingWords.append("Upgrade: websocket").append("\r\n");
-		handshakingWords.append("Origin: http://example.com").append("\r\n");
+		//handshakingWords.append("Origin: http://example.com").append("\r\n");
 		handshakingWords.append("Sec-WebSocket-Version: 13").append("\r\n");
 		handshakingWords.append("Sec-WebSocket-Key: O7Tk4xI04v+X91cuvefLSQ==").append("\r\n");
 		handshakingWords.append("\r\n");


### PR DESCRIPTION
![a408b67bae7d5562a5ed2d1e016afc90](https://github.com/user-attachments/assets/ab53ca46-69c5-4fe5-99d4-3ef8a23f9bfa)
When setting up a WebSocket server using Spring Boot, encountered connection issues when using the library. Comparing with Postman's headers, noticed an additional Origin field. Commenting out this field resolved the connection issue.