### PR TITLE
refactor(websocket): 在连接前先关闭现有连接

### DIFF
--- a/src/WebSocketClient.cpp
+++ b/src/WebSocketClient.cpp
@@ -245,6 +245,7 @@ namespace cyanray
 
 	void WebSocketClient::Connect(const string& hostname, int port, const string& path)
 	{
+        Shutdown();
 		PrivateMembers->wsSocket = hostname_connect(hostname, port);
 		if (PrivateMembers->wsSocket == INVALID_SOCKET)
 		{


### PR DESCRIPTION
- 添加了 Shutdown() 调用以确保连接前清理现有状态
- 防止旧连接残留导致的线程冲突问题
- 此次修复了在lostConnection时调用connect会导致错误的问题